### PR TITLE
Fix: Add yara dependency for SecretFinder

### DIFF
--- a/.github/workflows/_reusable-scan-pipeline.yml
+++ b/.github/workflows/_reusable-scan-pipeline.yml
@@ -176,7 +176,7 @@ jobs:
         if: steps.git_commit.outputs.changes_detected == 'true'
         run: |
           echo "🐍 Setting up Python and installing analysis tools..."
-          sudo apt-get update && sudo apt-get install -y python3-pip
+          sudo apt-get update && sudo apt-get install -y python3-pip yara
           pip install git+https://github.com/m4ll0k/SecretFinder.git
           pip install git+https://github.com/GerbenJavado/LinkFinder.git
 


### PR DESCRIPTION
This commit fixes a build failure in the 'Analyze Changed Files' step. The `SecretFinder` tool requires the `yara` package to be installed on the system, but it was missing from the runner's dependencies.

This change adds `yara` to the `apt-get install` command, ensuring that the prerequisites are met before `pip install` is called. This resolves the installation error and allows the analysis pipeline to run correctly.